### PR TITLE
CONNECTION+HTTP: Handle short file reads.

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -159,7 +159,7 @@ bool connection_splice_submit(Connection* conn, struct io_uring* uring, fd src, 
         }
     }
 
-    for (size_t remaining = len; remaining > 0; ) {
+    for (size_t remaining = len; remaining > 0;) {
         size_t req_len = MIN(PIPE_BUF_SIZE, remaining);
         bool   more    = remaining > PIPE_BUF_SIZE;
         A3_TRYB_MSG(event_splice_submit(EVT(conn), uring, src, len - remaining + file_offset,

--- a/src/connection.h
+++ b/src/connection.h
@@ -72,7 +72,10 @@ bool connection_reset(Connection*, struct io_uring*);
 
 Connection* connection_accept_submit(Listener*, struct io_uring*);
 bool connection_send_submit(Connection*, struct io_uring*, uint32_t send_flags, uint8_t sqe_flags);
-bool connection_splice_submit(Connection*, struct io_uring*, fd src, size_t len, uint8_t sqe_flags);
+bool connection_splice_submit(Connection*, struct io_uring*, fd src, size_t file_offset, size_t len,
+                              uint8_t sqe_flags);
+bool connection_splice_retry(Connection*, struct io_uring*, fd src, size_t in_buf,
+                             size_t file_offset, size_t remaining, uint8_t sqe_flags);
 bool connection_close_submit(Connection*, struct io_uring*);
 
 void connection_event_handle(Connection*, struct io_uring*, EventType, int32_t status,

--- a/src/http/response.c
+++ b/src/http/response.c
@@ -102,8 +102,11 @@ bool http_response_splice_handle(HttpConnection* conn, struct io_uring* uring, u
     assert(uring);
     assert(status >= 0);
 
+    if (flags & EVENT_FLAG_SPLICE_IN)
+        conn->response.body_sent += (size_t)status;
+
     if (!success) {
-        a3_log_fmt(LOG_ERROR, "Short splice %s of %d.",
+        a3_log_fmt(LOG_TRACE, "Short splice %s of %d.",
                    (flags & EVENT_FLAG_SPLICE_IN) ? "IN" : "OUT", status);
         if (flags & EVENT_FLAG_SPLICE_OUT) {
             A3_ERR("TODO: Handle short splice out.");
@@ -120,8 +123,6 @@ bool http_response_splice_handle(HttpConnection* conn, struct io_uring* uring, u
         return true;
     }
 
-    if (flags & EVENT_FLAG_SPLICE_IN)
-        conn->response.body_sent += (size_t)status;
     return http_response_handle(conn, uring);
 }
 


### PR DESCRIPTION
Under heavy load (>1k simultaneous connections), splices from a file
start to return short. This causes chains to break, and requests to
fail. This change introduces a simple mechanism to handle those short
reads simply by restarting the whole chain from the point of failure.
