### PR TITLE
callbacks

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -45,21 +45,14 @@
 #include "listen.h"
 #include "timeout.h"
 
-static bool connection_recv_submit(Connection*, struct io_uring*, uint32_t recv_flags,
-                                   uint8_t sqe_flags);
+static bool connection_recv_submit(Connection*, struct io_uring*, ConnectionHandler);
 static bool connection_timeout_submit(Connection* conn, struct io_uring* uring, time_t delay);
 
-static bool connection_recv_handle(Connection* conn, struct io_uring* uring, int32_t status,
-                                   bool chain);
+static void connection_recv_handle(EventTarget*, struct io_uring*, void* ctx, bool success,
+                                   int32_t status);
 static bool connection_timeout_handle(Timeout*, struct io_uring*);
 
 static TimeoutQueue connection_timeout_queue;
-
-static inline HttpConnection* connection_http(Connection* conn) {
-    assert(conn);
-
-    return A3_CONTAINER_OF(conn, HttpConnection, conn);
-}
 
 void connection_timeout_init() { timeout_queue_init(&connection_timeout_queue); }
 
@@ -86,275 +79,195 @@ bool connection_reset(Connection* conn, struct io_uring* uring) {
     return true;
 }
 
-// Submit an ACCEPT on the uring.
-Connection* connection_accept_submit(Listener* listener, struct io_uring* uring) {
-    assert(listener);
-    assert(uring);
-
-    Connection* ret = (Connection*)http_connection_new();
-    if (!ret)
-        return NULL;
-
-    ret->listener = listener;
-
-    ret->transport = listener->transport;
-    switch (ret->transport) {
-    case TRANSPORT_PLAIN:
-        ret->recv_submit = connection_recv_submit;
-        ret->recv_handle = connection_recv_handle;
-
-        ret->send_submit = connection_send_submit;
-        break;
-    case TRANSPORT_TLS:
-        A3_PANIC("TODO: TLS");
-    default:
-        A3_PANIC("Invalid transport.");
-    }
-
-    ret->addr_len = sizeof(ret->client_addr);
-
-    if (!event_accept_submit(EVT(ret), uring, listener->socket, &ret->client_addr,
-                             &ret->addr_len)) {
-        http_connection_free((HttpConnection*)ret, uring);
-        return NULL;
-    }
-
-    return ret;
-}
-
-// Submit a request to receive as much data as the buffer can handle.
-static bool connection_recv_submit(Connection* conn, struct io_uring* uring, uint32_t recv_flags,
-                                   uint8_t sqe_flags) {
-    assert(conn);
-    assert(uring);
-    (void)recv_flags;
-    (void)sqe_flags;
-
-    return event_recv_submit(EVT(conn), uring, conn->socket, a3_buf_write_ptr(&conn->recv_buf));
-}
-
-bool connection_send_submit(Connection* conn, struct io_uring* uring, uint32_t send_flags,
-                            uint8_t sqe_flags) {
+static inline void connection_drop(Connection* conn, struct io_uring* uring) {
     assert(conn);
     assert(uring);
 
-    A3Buffer* buf = &conn->send_buf;
-    return event_send_submit(EVT(conn), uring, conn->socket, a3_buf_read_ptr(buf), send_flags,
-                             sqe_flags);
+    a3_log_msg(LOG_WARN, "Dropping connection.");
+    // TODO: Make generic.
+    http_connection_free(connection_http(conn), uring);
 }
 
-#define PIPE_BUF_SIZE 65536ULL
+#define CTRYB(CONN, URING, T)                                                                      \
+    do {                                                                                           \
+        if (!(T)) {                                                                                \
+            connection_drop((CONN), (URING));                                                      \
+            return;                                                                                \
+        }                                                                                          \
+    } while (0)
 
-// Wraps splice so it can be used without a pipe.
-bool connection_splice_submit(Connection* conn, struct io_uring* uring, fd src, size_t file_offset,
-                              size_t len, uint8_t sqe_flags) {
+#define CTRYB_MAP(CONN, URING, T, E)                                                               \
+    do {                                                                                           \
+        if (!(T)) {                                                                                \
+            connection_drop((CONN), (URING));                                                      \
+            return (E);                                                                            \
+        }                                                                                          \
+    } while (0)
+
+// Call a connection callback, and close on failure.
+static inline void connection_handler_call(Connection* conn, struct io_uring* uring,
+                                           ConnectionHandler handler, bool success,
+                                           int32_t status) {
     assert(conn);
     assert(uring);
+    assert(handler);
 
-    if (!conn->pipe[0] && !conn->pipe[1]) {
-        a3_log_msg(LOG_TRACE, "Opening pipe.");
-        if (pipe(conn->pipe) < 0) {
-            a3_log_error(errno, "unable to open pipe");
-            return false;
-        }
-    }
+    if (handler(conn, uring, success, status))
+        return;
 
-    for (size_t remaining = len; remaining > 0;) {
-        size_t req_len = MIN(PIPE_BUF_SIZE, remaining);
-        bool   more    = remaining > PIPE_BUF_SIZE;
-        A3_TRYB_MSG(event_splice_submit(EVT(conn), uring, src, len - remaining + file_offset,
-                                        conn->pipe[1], req_len, 0, EVENT_FLAG_SPLICE_IN,
-                                        sqe_flags | IOSQE_IO_LINK, false),
-                    LOG_ERROR, "Failed to submit splice in.");
-        A3_TRYB_MSG(event_splice_submit(EVT(conn), uring, conn->pipe[0], (uint64_t)-1, conn->socket,
-                                        req_len, more ? SPLICE_F_MORE : 0, EVENT_FLAG_SPLICE_OUT,
-                                        sqe_flags | (more ? IOSQE_IO_LINK : 0), !more),
-                    LOG_ERROR, "Failed to submit splice out.");
-        if (more)
-            remaining -= PIPE_BUF_SIZE;
-        else
-            remaining = 0;
-    }
-
-    return true;
-}
-
-// Retry an interrupted splice chain.
-bool connection_splice_retry(Connection* conn, struct io_uring* uring, fd src, size_t in_buf,
-                             size_t file_offset, size_t remaining, uint8_t sqe_flags) {
-    assert(conn);
-    assert(uring);
-
-    bool more = remaining > 0;
-
-    if (in_buf &&
-        !event_splice_submit(EVT(conn), uring, conn->pipe[0], (uint64_t)-1, conn->socket, in_buf,
-                             more ? SPLICE_F_MORE : 0, EVENT_FLAG_SPLICE_OUT,
-                             sqe_flags | (more ? IOSQE_IO_LINK : 0), more ? false : true)) {
-        A3_ERR("Failed to submit splice.");
-        return false;
-    }
-
-    if (more)
-        return connection_splice_submit(conn, uring, src, file_offset, remaining, sqe_flags);
-    return true;
-}
-
-static bool connection_timeout_submit(Connection* conn, struct io_uring* uring, time_t delay) {
-    assert(conn);
-    assert(uring);
-
-    struct timespec t;
-    if (clock_gettime(CLOCK_MONOTONIC, &t) < 0)
-        return false;
-
-    conn->timeout.threshold.tv_sec  = t.tv_sec + delay;
-    conn->timeout.threshold.tv_nsec = t.tv_nsec;
-    conn->timeout.fire              = connection_timeout_handle;
-    return timeout_schedule(&connection_timeout_queue, &conn->timeout, uring);
-}
-
-bool connection_close_submit(Connection* conn, struct io_uring* uring) {
-    assert(conn);
-    assert(uring);
-
-    if (timeout_is_scheduled(&conn->timeout))
-        timeout_cancel(&conn->timeout);
-
-    return event_close_submit(EVT(conn), uring, conn->socket, 0, EVENT_FALLBACK_FORBID);
+    connection_drop(conn, uring);
 }
 
 // Handle the completion of an ACCEPT event.
-static bool connection_accept_handle(Connection* conn, struct io_uring* uring, int32_t status,
-                                     bool chain) {
-    assert(conn);
+static void connection_accept_handle(EventTarget* target, struct io_uring* uring, void* handler,
+                                     bool success, int32_t status) {
+    assert(target);
     assert(uring);
-    assert(!chain);
-    (void)chain;
+
+    Connection* conn = EVT_PTR(target, Connection);
 
     a3_log_msg(LOG_TRACE, "Accept connection.");
     conn->listener->accept_queued = false;
-    if (status < 0) {
+    if (!success) {
         a3_log_error(-status, "accept failed");
-        return false;
+        connection_drop(conn, uring);
+        return;
     }
     conn->socket = (fd)status;
 
-    A3_TRYB(connection_timeout_submit(conn, uring, CONNECTION_TIMEOUT));
-
-    return conn->recv_submit(conn, uring, 0, 0);
+    CTRYB(conn, uring, connection_timeout_submit(conn, uring, CONNECTION_TIMEOUT));
+    CTRYB(conn, uring, connection_recv_submit(conn, uring, handler));
 }
 
-static bool connection_close_handle(Connection* conn, struct io_uring* uring, int32_t status,
-                                    bool chain) {
-    assert(conn);
+static void connection_close_handle(EventTarget* target, struct io_uring* uring, void* ctx,
+                                    bool success, int32_t status) {
+    assert(target);
     assert(uring);
-    assert(!chain);
-    (void)chain;
+
+    Connection* conn = EVT_PTR(target, Connection);
 
     conn->socket = -1;
     if (status < 0)
         a3_log_error(-status, "close failed");
-    http_connection_free((HttpConnection*)conn, uring);
 
-    return true;
+    if (ctx)
+        connection_handler_call(conn, uring, ctx, success, status);
 }
 
-static bool connection_openat_handle(Connection* conn, struct io_uring* uring, int32_t status,
-                                     bool chain) {
-    assert(conn);
+static void connection_recv_handle(EventTarget* target, struct io_uring* uring, void* ctx,
+                                   bool success, int32_t status) {
+    assert(target);
     assert(uring);
-    assert(!chain);
-    (void)chain;
-    (void)status;
+    assert(ctx);
 
-    // FIXME: This is ugly and unnecessary coupling.
-    return http_response_handle((HttpConnection*)conn, uring);
-}
+    Connection* conn = EVT_PTR(target, Connection);
 
-static bool connection_read_handle(Connection* conn, struct io_uring* uring, bool success,
-                                   int32_t status, bool chain) {
-    assert(conn);
-    assert(uring);
-    assert(chain);
-    (void)uring;
-    (void)chain;
-
-    if (status < 0) {
-        a3_log_error(-status, "read failed");
-        return false;
+    if (status == 0 || status == -ECONNRESET) {
+        a3_log_msg(LOG_TRACE, "Connection closed by peer.");
+        connection_drop(conn, uring);
+        return;
     }
     if (!success) {
-        // TODO: Handle short reads.
-        a3_log_fmt(LOG_ERROR, "Short read of %d.", status);
-        return false;
-    }
-
-    a3_buf_wrote(&conn->send_buf, (size_t)status);
-    return true;
-}
-
-static bool connection_recv_handle(Connection* conn, struct io_uring* uring, int32_t status,
-                                   bool chain) {
-    assert(conn);
-    assert(uring);
-    assert(!chain);
-    (void)chain;
-
-    if (status == 0 || status == -ECONNRESET)
-        return connection_close_submit(conn, uring);
-    if (status < 0) {
         a3_log_error(-status, "recv failed");
-        return false;
+        connection_drop(conn, uring);
+        return;
     }
 
     a3_buf_wrote(&conn->recv_buf, (size_t)status);
 
-    HttpRequestResult rc = http_request_handle((HttpConnection*)conn, uring);
-    if (rc == HTTP_REQUEST_ERROR)
-        return false;
-    else if (rc == HTTP_REQUEST_NEED_DATA)
-        return conn->recv_submit(conn, uring, 0, 0);
-
-    return true;
+    connection_handler_call(conn, uring, ctx, success, status);
 }
 
-static bool connection_send_handle(Connection* conn, struct io_uring* uring, bool success,
-                                   int32_t status, bool chain) {
-    assert(conn);
+static void connection_send_handle(EventTarget* target, struct io_uring* uring, void* ctx,
+                                   bool success, int32_t status) {
+    assert(target);
     assert(uring);
+
+    Connection* conn = EVT_PTR(target, Connection);
 
     if (status < 0) {
         a3_log_error(-status, "send failed");
-        return false;
+        connection_drop(conn, uring);
+        return;
     }
     if (!success) {
         a3_log_fmt(LOG_ERROR, "Short send of %d.", status);
-        return false;
+        connection_drop(conn, uring);
+        return;
     }
 
     a3_buf_read(&conn->send_buf, (size_t)status);
 
-    if (chain)
-        return true;
-
-    return http_response_handle((HttpConnection*)conn, uring);
+    if (ctx)
+        connection_handler_call(conn, uring, ctx, success, status);
 }
 
-static bool connection_splice_handle(Connection* conn, struct io_uring* uring, uint32_t flags,
-                                     bool success, int32_t status, bool chain) {
-    assert(conn);
+static void connection_splice_handle(EventTarget* target, struct io_uring* uring, void* ctx,
+                                     bool success, int32_t status) {
+    assert(target);
     assert(uring);
+
+    Connection* conn = EVT_PTR(target, Connection);
 
     if (status < 0) {
         a3_log_error(-status, "splice failed");
-        return false;
+        connection_drop(conn, uring);
+        return;
+    }
+    if (!success) {
+        a3_log_fmt(LOG_ERROR, "Short splice out of %d.", status);
+        connection_drop(conn, uring);
     }
 
-    if (chain && success)
-        return true;
+    if (ctx)
+        connection_handler_call(conn, uring, ctx, success, status);
+}
 
-    return http_response_splice_handle((HttpConnection*)conn, uring, flags, success, status);
+static void connection_splice_in_handle(EventTarget* target, struct io_uring* uring, void* ctx,
+                                        bool success, int32_t status) {
+    assert(target);
+    assert(uring);
+
+    Connection* conn = EVT_PTR(target, Connection);
+
+    if (status < 0) {
+        a3_log_error(-status, "splice in failed");
+        connection_drop(conn, uring);
+        return;
+    }
+    if (!success)
+        a3_log_fmt(LOG_WARN, "Short splice of %d.", status);
+
+    if (ctx) {
+        ConnectionSpliceHandler handler = ctx;
+        if (!handler(conn, uring, SPLICE_IN, success, status))
+            connection_drop(conn, uring);
+    }
+}
+
+static void connection_splice_out_handle(EventTarget* target, struct io_uring* uring, void* ctx,
+                                         bool success, int32_t status) {
+    assert(target);
+    assert(uring);
+
+    Connection* conn = EVT_PTR(target, Connection);
+
+    if (status < 0) {
+        a3_log_error(-status, "splice out failed");
+        connection_drop(conn, uring);
+        return;
+    }
+    if (!success) {
+        a3_log_fmt(LOG_ERROR, "Short splice out of %d.", status);
+        connection_drop(conn, uring);
+        return;
+    }
+
+    if (ctx) {
+        ConnectionSpliceHandler handler = ctx;
+        if (!handler(conn, uring, SPLICE_OUT, success, status))
+            connection_drop(conn, uring);
+    }
 }
 
 static bool connection_timeout_handle(Timeout* timeout, struct io_uring* uring) {
@@ -367,49 +280,144 @@ static bool connection_timeout_handle(Timeout* timeout, struct io_uring* uring) 
                                       HTTP_RESPONSE_CLOSE);
 }
 
-void connection_event_handle(Connection* conn, struct io_uring* uring, EventType type,
-                             int32_t status, uint32_t flags) {
+// Submit an ACCEPT on the uring. The handler given will only be called upon the arrival of input
+// data.
+Connection* connection_accept_submit(Listener* listener, struct io_uring* uring,
+                                     ConnectionHandler handler) {
+    assert(listener);
+    assert(uring);
+    assert(handler);
+
+    // TODO: This needs to be generic over connection types. Perhaps just take as a parameter.
+    Connection* ret = (Connection*)http_connection_new();
+    if (!ret)
+        return NULL;
+
+    ret->listener  = listener;
+    ret->transport = listener->transport;
+    ret->addr_len  = sizeof(ret->client_addr);
+
+    CTRYB_MAP(ret, uring,
+              event_accept_submit(EVT(ret), uring, connection_accept_handle, handler,
+                                  listener->socket, &ret->client_addr, &ret->addr_len),
+              NULL);
+
+    return ret;
+}
+
+// Submit a request to receive as much data as the buffer can handle.
+bool connection_recv_submit(Connection* conn, struct io_uring* uring,
+                                   ConnectionHandler handler) {
+    assert(conn);
+    assert(uring);
+    assert(handler);
+
+    return event_recv_submit(EVT(conn), uring, connection_recv_handle, handler, conn->socket,
+                             a3_buf_write_ptr(&conn->recv_buf));
+}
+
+bool connection_send_submit(Connection* conn, struct io_uring* uring, ConnectionHandler handler,
+                            uint32_t send_flags, uint8_t sqe_flags) {
+    assert(conn);
+    assert(handler);
+    assert(uring);
+    return event_send_submit(EVT(conn), uring, connection_send_handle, handler, conn->socket,
+                             a3_buf_read_ptr(&conn->send_buf), send_flags, sqe_flags);
+}
+
+#define PIPE_BUF_SIZE 65536ULL
+
+// Wraps splice so it can be used without a pipe.
+bool connection_splice_submit(Connection* conn, struct io_uring* uring,
+                              ConnectionSpliceHandler splice_handler, ConnectionHandler handler,
+                              fd src, size_t file_offset, size_t len, uint8_t sqe_flags) {
+    assert(conn);
+    assert(uring);
+    assert(splice_handler);
+    assert(handler);
+
+    if (!conn->pipe[0] && !conn->pipe[1]) {
+        a3_log_msg(LOG_TRACE, "Opening pipe.");
+        if (pipe(conn->pipe) < 0) {
+            a3_log_error(errno, "unable to open pipe");
+            return false;
+        }
+    }
+
+    for (size_t remaining = len; remaining > 0;) {
+        size_t req_len = MIN(PIPE_BUF_SIZE, remaining);
+        bool   more    = remaining > PIPE_BUF_SIZE;
+        A3_TRYB_MSG(event_splice_submit(EVT(conn), uring, connection_splice_in_handle,
+                                        splice_handler, src, len - remaining + file_offset,
+                                        conn->pipe[1], req_len, 0, sqe_flags | IOSQE_IO_LINK),
+                    LOG_ERROR, "Failed to submit splice in.");
+        A3_TRYB_MSG(
+            event_splice_submit(EVT(conn), uring,
+                                more ? connection_splice_out_handle : connection_splice_handle,
+                                more ? (void*)splice_handler : (void*)handler, conn->pipe[0],
+                                (uint64_t)-1, conn->socket, req_len, more ? SPLICE_F_MORE : 0,
+                                sqe_flags | (more ? IOSQE_IO_LINK : 0)),
+            LOG_ERROR, "Failed to submit splice out.");
+        if (more)
+            remaining -= PIPE_BUF_SIZE;
+        else
+            remaining = 0;
+    }
+
+    return true;
+}
+
+// Retry an interrupted splice chain.
+bool connection_splice_retry(Connection* conn, struct io_uring* uring,
+                             ConnectionSpliceHandler splice_handler, ConnectionHandler handler,
+                             fd src, size_t in_buf, size_t file_offset, size_t remaining,
+                             uint8_t sqe_flags) {
+    assert(conn);
+    assert(uring);
+    assert(splice_handler);
+    assert(handler);
+
+    bool more = remaining > 0;
+
+    // Clear out data currently in the pipe.
+    if (in_buf &&
+        !event_splice_submit(EVT(conn), uring,
+                             more ? connection_splice_out_handle : connection_splice_handle,
+                             more ? (void*)splice_handler : (void*)handler, conn->pipe[0],
+                             (uint64_t)-1, conn->socket, in_buf, more ? SPLICE_F_MORE : 0,
+                             sqe_flags | (more ? IOSQE_IO_LINK : 0))) {
+        A3_ERR("Failed to submit splice.");
+        return false;
+    }
+
+    // Re-submit the chain.
+    if (more)
+        return connection_splice_submit(conn, uring, splice_handler, handler, src, file_offset,
+                                        remaining, sqe_flags);
+    return true;
+}
+
+static bool connection_timeout_submit(Connection* conn, struct io_uring* uring, time_t delay) {
     assert(conn);
     assert(uring);
 
-    if (status == -ECANCELED)
-        return;
+    struct timespec t;
+    A3_UNWRAPSD(clock_gettime(CLOCK_MONOTONIC, &t));
 
-    bool rc      = true;
-    bool chain   = flags & EVENT_FLAG_CHAIN;
-    bool success = !(flags & EVENT_FLAG_FAIL);
+    conn->timeout.threshold.tv_sec  = t.tv_sec + delay;
+    conn->timeout.threshold.tv_nsec = t.tv_nsec;
+    conn->timeout.fire              = connection_timeout_handle;
+    return timeout_schedule(&connection_timeout_queue, &conn->timeout, uring);
+}
 
-    switch (type) {
-    case EVENT_ACCEPT:
-        rc = connection_accept_handle(conn, uring, status, chain);
-        break;
-    case EVENT_CLOSE:
-        rc = connection_close_handle(conn, uring, status, chain);
-        break;
-    case EVENT_OPENAT_SYNTH:
-        rc = connection_openat_handle(conn, uring, status, chain);
-        break;
-    case EVENT_READ:
-        rc = connection_read_handle(conn, uring, success, status, chain);
-        break;
-    case EVENT_RECV:
-        rc = conn->recv_handle(conn, uring, status, chain);
-        break;
-    case EVENT_SEND:
-        rc = connection_send_handle(conn, uring, success, status, chain);
-        break;
-    case EVENT_SPLICE:
-        rc = connection_splice_handle(conn, uring, flags, success, status, chain);
-        break;
-    case EVENT_INVALID:
-    case EVENT_OPENAT:
-    case EVENT_STAT:
-    case EVENT_TIMEOUT:
-        A3_PANIC_FMT("Invalid event %d.", type);
-    }
+bool connection_close_submit(Connection* conn, struct io_uring* uring, ConnectionHandler handler) {
+    assert(conn);
+    assert(uring);
+    assert(handler);
 
-    if (!rc) {
-        a3_log_msg(LOG_WARN, "Connection failure. Closing.");
-        http_connection_free((HttpConnection*)conn, uring);
-    }
+    if (timeout_is_scheduled(&conn->timeout))
+        timeout_cancel(&conn->timeout);
+
+    return event_close_submit(EVT(conn), uring, connection_close_handle, handler, conn->socket, 0,
+                              EVENT_FALLBACK_ALLOW);
 }

--- a/src/event.h
+++ b/src/event.h
@@ -47,7 +47,7 @@ A3_SLL_DECLARE_METHODS(Event);
 
 typedef A3_SLL(Event) EventTarget;
 typedef void (*EventHandler)(EventTarget*, struct io_uring*, void* ctx, bool success,
-                              int32_t status);
+                             int32_t status);
 
 // Include this as a member to make an object a viable event target.
 #define EVENT_TARGET   EventTarget _events_queued

--- a/src/event.h
+++ b/src/event.h
@@ -38,33 +38,7 @@ A3_H_BEGIN
 #define EVENT_FALLBACK_ALLOW  true
 #define EVENT_FALLBACK_FORBID false
 
-#define EVENT_FLAG_CHAIN (1U)
-#define EVENT_FLAG_FAIL  (1U << 1)
-
-// Flags for specific events should start here. Flags specific to different events may collide.
-#define EVENT_FLAG_BOUNDARY (1UL << 16)
-
-#define EVENT_FLAG_SPLICE_IN  EVENT_FLAG_BOUNDARY
-#define EVENT_FLAG_SPLICE_OUT (EVENT_FLAG_BOUNDARY << 1)
-
-#define EVENT_TYPE_ENUM                                                                            \
-    _EVENT_TYPE(EVENT_ACCEPT)                                                                      \
-    _EVENT_TYPE(EVENT_CLOSE)                                                                       \
-    _EVENT_TYPE(EVENT_OPENAT)                                                                      \
-    _EVENT_TYPE(EVENT_OPENAT_SYNTH)                                                                \
-    _EVENT_TYPE(EVENT_READ)                                                                        \
-    _EVENT_TYPE(EVENT_RECV)                                                                        \
-    _EVENT_TYPE(EVENT_SEND)                                                                        \
-    _EVENT_TYPE(EVENT_SPLICE)                                                                      \
-    _EVENT_TYPE(EVENT_STAT)                                                                        \
-    _EVENT_TYPE(EVENT_TIMEOUT)                                                                     \
-    _EVENT_TYPE(EVENT_INVALID)
-
-typedef enum EventType {
-#define _EVENT_TYPE(E) E,
-    EVENT_TYPE_ENUM
-#undef _EVENT_TYPE
-} EventType;
+#define EVENT_NO_QUEUE false
 
 typedef struct Event Event;
 
@@ -72,38 +46,40 @@ A3_SLL_DEFINE_STRUCTS(Event);
 A3_SLL_DECLARE_METHODS(Event);
 
 typedef A3_SLL(Event) EventTarget;
+typedef void (*EventHandler)(EventTarget*, struct io_uring*, void* ctx, bool success,
+                              int32_t status);
 
 // Include this as a member to make an object a viable event target.
 #define EVENT_TARGET   EventTarget _events_queued
 #define EVT(O)         (&(O)->_events_queued)
 #define EVT_PTR(T, TY) A3_CONTAINER_OF((T), TY, _events_queued)
 
-A3CString event_type_name(EventType);
-
 struct io_uring event_init(void);
 
-bool event_accept_submit(EventTarget*, struct io_uring*, fd socket,
+bool event_accept_submit(EventTarget*, struct io_uring*, EventHandler, void* ctx, fd socket,
                          struct sockaddr_in* out_client_addr, socklen_t* inout_addr_len);
-bool event_close_submit(EventTarget*, struct io_uring*, fd file, uint32_t sqe_flags,
-                        bool fallback_sync);
-bool event_openat_submit(EventTarget*, struct io_uring*, fd dir, A3CString path, int32_t open_flags,
-                         mode_t mode);
-bool event_read_submit(EventTarget*, struct io_uring*, fd file, A3String out_data, size_t nbytes,
-                       off_t offset, uint32_t sqe_flags);
-bool event_recv_submit(EventTarget*, struct io_uring*, fd socket, A3String out_data);
-bool event_send_submit(EventTarget*, struct io_uring*, fd socket, A3CString data,
-                       uint32_t send_flags, uint32_t sqe_flags);
-bool event_splice_submit(EventTarget*, struct io_uring*, fd in, uint64_t off_in, fd out, size_t len,
-                         uint32_t splice_flags, uint32_t event_flags, uint32_t sqe_flags,
-                         bool force_handle);
-bool event_stat_submit(EventTarget*, struct io_uring*, A3CString path, uint32_t field_mask,
-                       struct statx*, uint32_t sqe_flags);
-bool event_timeout_submit(EventTarget*, struct io_uring*, Timespec*, uint32_t timeout_flags);
+bool event_close_submit(EventTarget*, struct io_uring*, EventHandler, void* ctx, fd file,
+                        uint32_t sqe_flags, bool fallback_sync);
+bool event_openat_submit(EventTarget*, struct io_uring*, EventHandler, void* ctx, fd dir,
+                         A3CString path, int32_t open_flags, mode_t mode);
+bool event_read_submit(EventTarget*, struct io_uring*, EventHandler, void* ctx, fd file,
+                       A3String out_data, size_t nbytes, off_t offset, uint32_t sqe_flags);
+bool event_recv_submit(EventTarget*, struct io_uring*, EventHandler, void* ctx, fd socket,
+                       A3String out_data);
+bool event_send_submit(EventTarget*, struct io_uring*, EventHandler, void* ctx, fd socket,
+                       A3CString data, uint32_t send_flags, uint32_t sqe_flags);
+bool event_splice_submit(EventTarget*, struct io_uring*, EventHandler, void* ctx, fd in,
+                         uint64_t off_in, fd out, size_t len, uint32_t splice_flags,
+                         uint32_t sqe_flags);
+bool event_stat_submit(EventTarget*, struct io_uring*, EventHandler, void* ctx, A3CString path,
+                       uint32_t field_mask, struct statx*, uint32_t sqe_flags);
+bool event_timeout_submit(EventTarget*, struct io_uring*, EventHandler, void* ctx, Timespec*,
+                          uint32_t timeout_flags);
 
 // Synthesize an event. This Event is _not_ queued, but is useful for situations
 // in which one completion from the uring must notify multiple targets. See
 // file.c for an example of usage.
-Event* event_create(EventTarget*, EventType);
+Event* event_create(EventTarget*, EventHandler, void* ctx);
 
 bool event_cancel_all(EventTarget*);
 

--- a/src/event/handle.cc
+++ b/src/event/handle.cc
@@ -51,7 +51,8 @@ void Event::handle(struct io_uring& uring) {
 
     delete this;
 
-    h(t, &uring, ctx, succeeded, st);
+    if (h)
+        h(t, &uring, ctx, succeeded, st);
 }
 
 // Handle all events pending on the queue.

--- a/src/event/handle.cc
+++ b/src/event/handle.cc
@@ -113,6 +113,10 @@ void event_handle_all(EventQueue* queue, struct io_uring* uring) {
 
         event->set_status(status);
 
+        if (!event->success && event->status == -ECANCELED) {
+            delete event;
+            continue;
+        }
 
         // Add to the to-process queue.
         A3_SLL_ENQUEUE(Event)(queue, event);

--- a/src/event/mod.cc
+++ b/src/event/mod.cc
@@ -118,7 +118,6 @@ static bool event_close_fallback(Event* event, struct io_uring& uring, fd file) 
 bool event_close_submit(EventTarget* target, struct io_uring* uring, EventHandler handler,
                         void* handler_ctx, fd file, uint32_t sqe_flags, bool fallback_sync) {
     assert(uring);
-    assert(handler);
     assert(file >= 0);
 
     unique_ptr<Event> event;
@@ -178,7 +177,7 @@ bool event_read_submit(EventTarget* target, struct io_uring* uring, EventHandler
 
     auto read_size = static_cast<uint32_t>(MIN(out_data.len, nbytes));
 
-    auto event = Event::create(target, handler, handler_ctx, read_size);
+    auto event = Event::create(target, handler, handler_ctx, static_cast<int32_t>(read_size));
     A3_TRYB(event);
 
     auto sqe = event_get_sqe(*uring);
@@ -225,7 +224,7 @@ bool event_send_submit(EventTarget* target, struct io_uring* uring, EventHandler
     auto sqe = event_get_sqe(*uring);
     A3_TRYB(sqe);
 
-    io_uring_prep_send(sqe.get(), socket, data.ptr, data.len, send_flags);
+    io_uring_prep_send(sqe.get(), socket, data.ptr, data.len, static_cast<int32_t>(send_flags));
     event_sqe_fill(move(event), move(sqe), sqe_flags);
 
     return true;
@@ -247,7 +246,7 @@ bool event_splice_submit(EventTarget* target, struct io_uring* uring, EventHandl
     A3_TRYB(sqe);
 
     io_uring_prep_splice(sqe.get(), in, off_in, out, static_cast<uint64_t>(-1),
-                         static_cast<int32_t>(len), SPLICE_F_MOVE | splice_flags);
+                         static_cast<uint32_t>(len), SPLICE_F_MOVE | splice_flags);
     event_sqe_fill(move(event), move(sqe), sqe_flags);
 
     return true;

--- a/src/file.h
+++ b/src/file.h
@@ -48,7 +48,6 @@ struct statx* file_handle_stat(FileHandle*);
 A3CString     file_handle_path(FileHandle*);
 bool          file_handle_waiting(FileHandle*);
 bool          file_handle_close(FileHandle*, struct io_uring*);
-void file_handle_event_handle(FileHandle*, struct io_uring*, int32_t status, uint32_t flags);
-void file_cache_destroy(struct io_uring*);
+void          file_cache_destroy(struct io_uring*);
 
 A3_H_END

--- a/src/file.h
+++ b/src/file.h
@@ -29,17 +29,21 @@
 
 A3_H_BEGIN
 
-typedef struct FileHandle FileHandle;
 struct statx;
+
+typedef struct FileHandle FileHandle;
+typedef void (*FileHandleHandler)(EventTarget* target, struct io_uring*, void* ctx, bool success,
+                                  int32_t status);
 
 #define FILE_STATX_MASK (STATX_TYPE | STATX_MTIME | STATX_INO | STATX_SIZE)
 
-void          file_cache_init(void);
-FileHandle*   file_open(EventTarget*, struct io_uring*, A3CString path, int32_t flags);
-FileHandle*   file_openat(EventTarget*, struct io_uring*, FileHandle* dir, A3CString name,
-                          int32_t flags);
-fd            file_handle_fd(FileHandle*);
-fd            file_handle_fd_unchecked(FileHandle*);
+void        file_cache_init(void);
+FileHandle* file_open(EventTarget*, struct io_uring*, FileHandleHandler, void* ctx, A3CString path,
+                      int32_t flags);
+FileHandle* file_openat(EventTarget*, struct io_uring*, FileHandleHandler, void* ctx,
+                        FileHandle* dir, A3CString name, int32_t flags);
+fd          file_handle_fd(FileHandle*);
+fd          file_handle_fd_unchecked(FileHandle*);
 struct statx* file_handle_stat(FileHandle*);
 A3CString     file_handle_path(FileHandle*);
 bool          file_handle_waiting(FileHandle*);

--- a/src/http/connection.h
+++ b/src/http/connection.h
@@ -68,3 +68,9 @@ A3_ALWAYS_INLINE bool http_connection_keep_alive(HttpConnection* conn) {
         return false;
     return conn->connection_type == HTTP_CONNECTION_TYPE_KEEP_ALIVE;
 }
+
+A3_ALWAYS_INLINE HttpConnection* connection_http(Connection* conn) {
+    assert(conn);
+
+    return A3_CONTAINER_OF(conn, HttpConnection, conn);
+}

--- a/src/http/request.h
+++ b/src/http/request.h
@@ -44,4 +44,4 @@ HttpResponse*   http_request_response(HttpRequest*);
 void http_request_init(HttpRequest*);
 void http_request_reset(HttpRequest*);
 
-HttpRequestResult http_request_handle(HttpConnection*, struct io_uring*);
+bool http_request_handle(Connection*, struct io_uring*, bool success, int32_t status);

--- a/src/http/response.c
+++ b/src/http/response.c
@@ -75,8 +75,8 @@ void http_response_reset(HttpResponse* resp) {
 }
 
 // Respond to a mid-response event.
-bool http_response_handle(Connection* connection, struct io_uring* uring, bool success,
-                          int32_t status) {
+static bool http_response_handle(Connection* connection, struct io_uring* uring, bool success,
+                                 int32_t status) {
     assert(connection);
     assert(uring);
     assert(success);

--- a/src/http/response.h
+++ b/src/http/response.h
@@ -33,8 +33,6 @@ typedef struct HttpResponse {
 void http_response_init(HttpResponse*);
 void http_response_reset(HttpResponse*);
 
-bool http_response_handle(Connection*, struct io_uring*, bool success, int32_t status);
-
 #define HTTP_RESPONSE_CLOSE true
 #define HTTP_RESPONSE_ALLOW false
 bool http_response_error_submit(HttpResponse*, struct io_uring*, HttpStatus, bool close);

--- a/src/http/response.h
+++ b/src/http/response.h
@@ -33,9 +33,7 @@ typedef struct HttpResponse {
 void http_response_init(HttpResponse*);
 void http_response_reset(HttpResponse*);
 
-bool http_response_handle(HttpConnection*, struct io_uring*);
-bool http_response_splice_handle(HttpConnection*, struct io_uring*, uint32_t flags, bool success,
-                                 int32_t status);
+bool http_response_handle(Connection*, struct io_uring*, bool success, int32_t status);
 
 #define HTTP_RESPONSE_CLOSE true
 #define HTTP_RESPONSE_ALLOW false

--- a/src/http/types.h
+++ b/src/http/types.h
@@ -83,7 +83,7 @@ typedef enum HttpContentType {
     _STATUS(408, HTTP_STATUS_TIMEOUT, "Request Timeout")                                           \
     _STATUS(413, HTTP_STATUS_PAYLOAD_TOO_LARGE, "Payload Too Large")                               \
     _STATUS(414, HTTP_STATUS_URI_TOO_LONG, "URI Too Long")                                         \
-    _STATUS(418, HTTP_STATUS_IM_A_TEAPOT, "I'm a teapot")                                          \
+    _STATUS(418, HTCPCP_STATUS_IM_A_TEAPOT, "I'm a teapot")                                        \
     _STATUS(431, HTTP_STATUS_HEADER_TOO_LARGE, "Request Header Fields Too Large")                  \
     _STATUS(500, HTTP_STATUS_SERVER_ERROR, "Internal Server Error")                                \
     _STATUS(501, HTTP_STATUS_NOT_IMPLEMENTED, "Not Implemented")                                   \

--- a/src/listen.c
+++ b/src/listen.c
@@ -31,6 +31,7 @@
 #include "config.h"
 #include "connection.h"
 #include "forward.h"
+#include "http/request.h"
 
 static fd socket_listen(in_port_t port) {
     fd ret;
@@ -65,7 +66,8 @@ Connection* listener_accept_submit(Listener* listener, struct io_uring* uring) {
     assert(!listener->accept_queued);
     assert(uring);
 
-    Connection* ret = connection_accept_submit(listener, uring);
+    // TODO: Generic over connection types.
+    Connection* ret = connection_accept_submit(listener, uring, http_request_handle);
     if (ret)
         listener->accept_queued = true;
 

--- a/src/timeout.h
+++ b/src/timeout.h
@@ -33,7 +33,7 @@ A3_H_BEGIN
 struct Timeout;
 typedef struct Timeout Timeout;
 
-typedef bool (*TimeoutExec)(Timeout*, struct io_uring*);
+typedef void (*TimeoutExec)(Timeout*, struct io_uring*);
 
 A3_LL_DEFINE_STRUCTS(Timeout)
 


### PR DESCRIPTION
EVENT+CONNECTION+HTTP: Rework event system to use callbacks.

Instead of dispatching on event type and relying on state to determine
which handler to call, simply take callbacks when submitting events.

This greatly simplifies chain handling, and eliminiates the need for
the convoluted event flags system.
